### PR TITLE
Compute the minimum alternating tax

### DIFF
--- a/taxcalc/cit_function_names_egypt.json
+++ b/taxcalc/cit_function_names_egypt.json
@@ -18,5 +18,6 @@
   "16": "Net_tax_base",
   "17": "Net_tax_base_behavior",  
   "18": "Net_tax_base_Egyp_Pounds",
-  "19": "cit_liability"
+  "19": "mat_liability",
+  "20": "cit_liability"
 }

--- a/taxcalc/cit_functions_egypt.py
+++ b/taxcalc/cit_functions_egypt.py
@@ -249,9 +249,16 @@ def Net_tax_base_Egyp_Pounds(Net_tax_base_behavior, Exchange_rate, Net_tax_base_
 DEBUG = False
 DEBUG_IDX = 0
 
+@iterate_jit(nopython=True)
+def mat_liability(mat_rate, Net_accounting_profit, mat_liability):
+    """
+    Compute Minimum Alternate Tax as a percentage of the net accounting profit
+    """
+    mat_liability = Net_accounting_profit*mat_rate
+    return mat_liability
 
 @iterate_jit(nopython=True)
-def cit_liability(cit_rate_oil, cit_rate_hotels, cit_rate_banks, cit_rate_genbus, Sector, Net_tax_base_Egyp_Pounds, citax):
+def cit_liability(cit_rate_oil, cit_rate_hotels, cit_rate_banks, cit_rate_genbus, Sector, Net_tax_base_Egyp_Pounds, mat_liability ,citax):
     """
     Compute tax liability given the corporate rate
     """
@@ -266,9 +273,10 @@ def cit_liability(cit_rate_oil, cit_rate_hotels, cit_rate_banks, cit_rate_genbus
         citax = cit_rate_oil * taxinc
     elif Sector == 3:
         citax = cit_rate_genbus * taxinc
-        
-    return citax
 
+    if (citax < mat_liability):
+        citax = mat_liability
+    return citax
 
 
 

--- a/taxcalc/cit_records_variables_egypt.json
+++ b/taxcalc/cit_records_variables_egypt.json
@@ -571,6 +571,13 @@
       "form": {
         "2020": "carried forward from Table 411B  - Tax Return Legal Persons"
       }
+    },
+    "mat_liability": {
+      "type": "float",
+      "desc": "Minimum alternative tax liability",
+      "form": {
+        "2020": ""
+      }
     }
   }
 }

--- a/taxcalc/current_law_policy_cit_egypt.json
+++ b/taxcalc/current_law_policy_cit_egypt.json
@@ -249,6 +249,31 @@
         "out_of_range_maxmsg": "",
         "out_of_range_action": "stop"
     }, 
+    "_mat_rate": {
+        "long_name": "rate at which corporates minimum alternative tax is calculated",
+        "description": "Minimum Alternative Tax rate",
+        "itr_ref": "Tax Law",
+        "notes": "",
+        "row_var": "Year",
+        "row_label": [
+            "2020"
+        ],
+        "start_year": 2020,
+        "cpi_inflatable": false,
+        "cpi_inflated": false,
+        "col_var": "Sector",
+        "col_label": ["Hotels", "Banks", "Gen Business"],
+        "boolean_value": false,
+        "integer_value": false,
+        "value": [0.0],
+        "range": {
+            "min": 0.0,
+            "max": 1.0
+        },
+        "out_of_range_minmsg": "",
+        "out_of_range_maxmsg": "",
+        "out_of_range_action": "stop"
+    }, 
     "_Donations_NGO_rate": {
         "long_name": "Deduction rate for donations to NGO",
         "description": "as % of Net taxable profits",


### PR DESCRIPTION
Added the minimum tax rate acceptable for cit liability.
Minimum tax calculated on the net accounting profit.
@rajivkumar1975 please check